### PR TITLE
Adds spaces after hashes so markdown formatting works

### DIFF
--- a/meetups/2014-december/readme.md
+++ b/meetups/2014-december/readme.md
@@ -1,8 +1,8 @@
-#Ladies Who Code LDN | [December 2014](http://www.meetup.com/Ladies-Who-Code-UK/events/217655562/)
+# Ladies Who Code LDN | [December 2014](http://www.meetup.com/Ladies-Who-Code-UK/events/217655562/)
 
 In honour of the giving season, our December meetup was on open source!
 
-##Speakers
+## Speakers
 **[Trisha Gee](http://trishagee.com/)**, all the way from Sevilla in Spain, is an expert in Java high performance systems, is passionate about enabling developer productivity and currently works for MongoDB, an open-source document database, and the leading NoSQL database. She will be giving us insight into what it's like working within and maintaining an open source project.
 
 **Oli Evans**, Co-Founder of [TABLEFLIP](http://tableflip.io/) and organiser of the NodeBots and Meteor London meetups (as well as being a mentor at NodeSchool and many other things), is also an avid contributor to open source projects.
@@ -10,7 +10,7 @@ He and **[Natalia Baltazar](https://twitter.com/natalialkb)** from [Founders & C
 
 **Ilona Filipi**, Co-Founder & MD of the [Moove Agency](http://www.mooveagency.com/) will be talking about the benefits and challenges of building a business ontop of an open source project (in this case, Wordpress). She'll also be talking about all the ways you can get involved in open source aside from contributing code.
 
-##Speaker decks:
+## Speaker decks:
 + [Trisha Gee](https://twitter.com/trisha_gee) on [Working in Open Source](http://www.slideshare.net/trishagee/working-in-open-source)
 + [Ilona Filipi](https://twitter.com/) on [The Challenges & Opportunities of Working with Open Source](http://www.slideshare.net/IlonaFilipi/the-challenges-and-opportunities-of-working-with-open-source-and-how-to-contribute-back)
 + [Oli Evans](https://twitter.com/olizilla) & [Natalia Baltazar](https://twitter.com/nataliaLKB) on [Open it Up](http://olizilla.github.io/open-it-up)

--- a/meetups/2015-april/readme.md
+++ b/meetups/2015-april/readme.md
@@ -1,4 +1,4 @@
-#Ladies Who Code LDN | [April 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/220599100/)
+# Ladies Who Code LDN | [April 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/220599100/)
 
 For those who made it to our February 'Everyone's new at something' meetup, [Maya Bonkowski](https://twitter.com/MayaInnoNinja) who spoke about Coding on the metal (on the processor) was our speaker again in April; back by popular demand!
 This month she discussed **_Low-level graphics with math and *those* dirty memory pointers ;)_**
@@ -10,11 +10,11 @@ A very brief intro into:
 
 And how to use all of the above good stuff to mess around in video frame buffers to do realtime effects.
 
-##Speaker deck:
+## Speaker deck:
 + To be added
 
 
-##Book recommendations & links from Maya:
+## Book recommendations & links from Maya:
 
 + The best C++ book Maya's come across to learn from is Andrew Koenig's ["Accelerated C++"](http://www.amazon.co.uk/Accelerated-Practical-Programming-Example-Series/dp/020170353X) 
 + All the Pointer Code was much more pure C and to learn that the source is still Kernighan and Ritchie's ["The C Programming language"](http://www.amazon.co.uk/C-Programming-Language-2nd/dp/0131103628/ref=sr_1_1)

--- a/meetups/2015-august/readme.md
+++ b/meetups/2015-august/readme.md
@@ -1,4 +1,4 @@
-#Ladies Who Code LDN | [August 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/224306287/)
+# Ladies Who Code LDN | [August 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/224306287/)
 
 In this month's beginner friendly meetup, [Frances Buontempo](https://twitter.com/fbuontempo) animated particles in a 2 dimensional paper bag. She showed us the various machine learning algorithms she uses to ensure the particle can escape the bag.  
 

--- a/meetups/2015-december/readme.md
+++ b/meetups/2015-december/readme.md
@@ -1,4 +1,4 @@
-#Ladies Who Code LDN | [December 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/226673924/)
+# Ladies Who Code LDN | [December 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/226673924/)
 
 In honor of the festive season, Ladies Who Code is partnered with [Codebar](http://www.codebar.io), [24 Pull Requests](http://www.24pullrequests.com) and [YourFirstPR](http://yourfirstpr.github.io/) for a special day of contributing to open source projects. 
 

--- a/meetups/2015-february/readme.md
+++ b/meetups/2015-february/readme.md
@@ -1,8 +1,8 @@
-#Ladies Who Code LDN | February 2015
+# Ladies Who Code LDN | February 2015
 
 This month's meetup was around the topic 'Everyone is new at something'.
 
-##Speaker decks:
+## Speaker decks:
 + [Blanca Tortajada](https://twitter.com/blanca_tp) on [HTML & CSS](https://github.com/BlancaTortajada/lwc-slides) plus a link to [her demo](https://github.com/BlancaTortajada/lwc-demo)
 + [Vasileia](https://twitter.com/supervasi) & [Vedika](https://twitter.com/vedikad) on a number of [non-web specific backend technologies](/LWC-backend-technologies.pdf)
 + Maya Bonkowski on Coding on the Metal (slides to come)

--- a/meetups/2015-june/readme.md
+++ b/meetups/2015-june/readme.md
@@ -1,4 +1,4 @@
-#Ladies Who Code LDN | [June 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/222452944/)
+# Ladies Who Code LDN | [June 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/222452944/)
 
 This month's meetup was on Test Driven Development for Javascript. Natalia introduced the concept of TDD and Nelson guided a [mini workshop using QUnit and testing in the browser](#speaker-decks--materials).    
 _Although the meetup concentrated on full stack Javascript testing, the principles of TDD can be applied to any development environment._
@@ -7,7 +7,7 @@ _Although the meetup concentrated on full stack Javascript testing, the principl
 
 [Natalia Baltazar](https://github.com/NataliaLKB) is a [Founders & Coders](http://www.foundersandcoders.com/academy/) alumni who has been a developer for 7 months now. She has already worked on projects for Camden Council and a freighting company and is a strong proponent of TDD.
 
-##Speaker decks & materials:
+## Speaker decks & materials:
 **Please remember to star repos on github if you like them so they get more exposure!):**    
 + [Natalia](https://twitter.com/natalialkb) on [what Test Driven Development is](http://nataliabaltazar.me/tdd)
 + [Nelson](https://twitter.com/nelsonic) took us through his ['Learn TDD'](https://github.com/nelsonic/learn-tdd) tutorial for beginners.

--- a/meetups/2015-march/readme.md
+++ b/meetups/2015-march/readme.md
@@ -1,29 +1,29 @@
-#Ladies Who Code LDN | March 2015
+# Ladies Who Code LDN | March 2015
 
 This month's meetup was a **Public Speaking workshop for Novices** with [Trisha Gee](https://twitter.com/trisha_gee) and lots of great input from [Mazz Mosley](https://twitter.com/mnowster).
 
-##Speaker deck:
+## Speaker deck:
 Trisha's slides [can be found on slideshare here](http://www.slideshare.net/trishagee/speaker-clinic-novice-speakers).
 
-##Notes:
+## Notes:
 LWC member [Sarah Knight has taken some excellent notes](https://twitter.com/scarerkite/status/573858676722810881) which you should definitely check out.
 The below are rough notes taken by [Ines](https://twitter.com/iteles) throughout and roughly organised into categories (given a lot of the great content from the night was a result of questions asked by everyone there). **Pull requests welcome** for any changes and additional points worth sharing with everyone!
 
-####Dealing with difficult questions
+#### Dealing with difficult questions
 + Set expectations upfront on whether you’ll have time to answer questions
 + If you’re super nervous at the end of the talk, it’s ok to say ‘I’m sure you’ll appreciate, it’s pretty nerve-wracking to be up here so I won’t be taking any questions from the stage but come find me after’
 + If you get a question and you don't know what some of the terms are referring to: "Can you clarify for everyone what x y and z mean to make sure everyone’s on the same page?"
 + **Always take things in the best possible way.** If people don’t ask any questions, that must mean you've already answered all of their questions!
 + It's ok to say you don't know, but point people in the direction of who does
 
-####Preparing a talk
+#### Preparing a talk
 + For calls for proposals, make titles either catchy or buzz word filled (and indicate the level your talk is aimed at)
 + Recommended reading for putting together the actual presentation: [Presentation Patterns](http://www.amazon.co.uk/Presentation-Patterns-Techniques-Crafting-Presentations/dp/0321820800)
 + Find **3 big things** you want to impart and build your talk around those
 + **Repetition is good** - it'll be awkward for you, but it's positive!
 
 
-####Practicing a talk
+#### Practicing a talk
 + **Everyone has different ways of practicing** - you could practice once or write out your whole script verbatim
 + Practicing a 5 min talk is more about just checking you're not going crazy over time
 + For longer talks - practice at least once out loud
@@ -33,7 +33,7 @@ The below are rough notes taken by [Ines](https://twitter.com/iteles) throughout
   + Try them out especially at meetups that film you and watch it back _(hint: LWC London will have optional recording of talks from April 2015 onwards!)_
   + Start a book club and have everyone present for 5 mins, teaching or talking through something that you struggled with
 
-####Getting comfortable with presenting
+#### Getting comfortable with presenting
   + **Co-presenting** is a really great way to get started
   + **_For eye contact:_** Just scan the crowd; you don't really have to make eye contact
   + **_On speaking slower:_** Don't be afraid of silence, it's ok to stop. For a 50 minute talk, try to have max 40 mins of content so you're forced to slow down.

--- a/meetups/2015-may/readme.md
+++ b/meetups/2015-may/readme.md
@@ -1,17 +1,17 @@
-#Ladies Who Code LDN | [April 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/221212588/)
+# Ladies Who Code LDN | [April 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/221212588/)
 
-###Part 1: Learn about the exciting things that [ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla) is doing for Javascript with [_Gem Barrett_](https://twitter.com/gembarrett)
+### Part 1: Learn about the exciting things that [ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla) is doing for Javascript with [_Gem Barrett_](https://twitter.com/gembarrett)
 As the new standard, ES6 adds a lot of exciting features to the Javascript toolbox. Gem will focus on the parts you can integrate into everyday coding tasks and give a brief overview of the more advanced features.
 
 _Web developer by day, iOS app developer by night and with a background in design, Gem describes herself simply as a "creative Chimera with an API addiction". Mostly self-taught, she  credits Javascript with awakening her love of programming, which has led to a career working with brands such as Volkswagen and Unilever._
 
-###Part 2: WebGL and Three.js with [_Mairead Buchan_](https://twitter.com/tiny_m)
+### Part 2: WebGL and Three.js with [_Mairead Buchan_](https://twitter.com/tiny_m)
 
 Learn the basics 3D motion geometry and the use of WebGL for making 3D graphics in the Browser with Javascript and the Three.js library (mini coding workshop).
 
 _Mairead is a creative web developer, based in London, specialising in exciting interactive experiences. She is interested in any technology that pushes the boundaries of web development and always looking for new ideas to harness what the internet can do for us._
 
-##Speaker decks & materials:
+## Speaker decks & materials:
 + [Gem Barrett]() with [An Overview of ES6](/Gem-Barrett-on-ES6-LWC-talk-materials)
 + [Mairead Buchan](https://twitter.com/tiny_m) on [WebGL & Three.js](http://www.emdeebeebee.com/lwc-workshop)
   * Mairead's [three.js workshop material](https://github.com/mairead/lwc-boilerplate)

--- a/meetups/2015-november/readme.md
+++ b/meetups/2015-november/readme.md
@@ -1,7 +1,7 @@
-#Ladies Who Code LDN | [November 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/226058341/)
+# Ladies Who Code LDN | [November 2015](http://www.meetup.com/Ladies-Who-Code-UK/events/226058341/)
 
 
-###Part 1: Coding for the unhappy paths - presented by [_Lindsey Dew_](http://www.theguardian.com/profile/lindsey-dew)
+### Part 1: Coding for the unhappy paths - presented by [_Lindsey Dew_](http://www.theguardian.com/profile/lindsey-dew)
 
 Often when we write code we focus on what happens when everything works as expected, but what happens when things fail? In Scala we can make use of the type system to develop code which behaves in an expected way even if the services it depends on fail.
 
@@ -11,7 +11,7 @@ _Lindsey is a software developer at The Guardian and writes code in Scala on a d
 
 </br>
 
-###Part 2: Introduction to functional programming - presented by [_Endre Galaczi_](https://twitter.com/galacziendre)
+### Part 2: Introduction to functional programming - presented by [_Endre Galaczi_](https://twitter.com/galacziendre)
 
 Endre gave us an introduction to functional programming and made it more accessible by comparing it to JavaScript.
 

--- a/meetups/2015-october/readme.md
+++ b/meetups/2015-october/readme.md
@@ -1,4 +1,4 @@
-#Ladies Who Code LDN | [October 2015 - Lightning Talks, All Things Code](http://www.meetup.com/Ladies-Who-Code-UK/events/224931063/)
+# Ladies Who Code LDN | [October 2015 - Lightning Talks, All Things Code](http://www.meetup.com/Ladies-Who-Code-UK/events/224931063/)
 
 This month we had a brilliant round of lightning talks from our very own members! The subjects were wide ranging and the questions from the audience were on point. We'll definitely be running these again.
 

--- a/meetups/2016-december/readme.md
+++ b/meetups/2016-december/readme.md
@@ -1,4 +1,4 @@
-#Ladies of Code LDN | [December 2016 - 24 Pull Requests event](https://www.meetup.com/Ladies-of-Code-UK/events/235269913/)
+# Ladies of Code LDN | [December 2016 - 24 Pull Requests event](https://www.meetup.com/Ladies-of-Code-UK/events/235269913/)
 
 We are passionate about open source and this event format allows us to spend some time together to make open source contributions.
 

--- a/meetups/2016-may/readme.md
+++ b/meetups/2016-may/readme.md
@@ -1,7 +1,7 @@
-#Ladies of Code LDN | [May 2016](http://www.meetup.com/Ladies-of-Code-UK/events/229486669/)
+# Ladies of Code LDN | [May 2016](http://www.meetup.com/Ladies-of-Code-UK/events/229486669/)
 
 
-###Part 1: My journey towards software craftsmanship - presented by [_Franziska Sauerwein_](https://twitter.com/singsalad)
+### Part 1: My journey towards software craftsmanship - presented by [_Franziska Sauerwein_](https://twitter.com/singsalad)
 
 Franzi talked about how she got into coding, about her career path and how she trained to become a software craftswoman. She explained what software craftsmanship is. Having moved to London from Germany to work for Codurance, she is now very active in the London software craftsmanship community.
 
@@ -11,7 +11,7 @@ _Franzi is a software craftswoman at Codurance._
 
 </br>
 
-###Part 2: A software apprenticeship - presented by [_Rabea Gleissner_](https://twitter.com/aebaR)
+### Part 2: A software apprenticeship - presented by [_Rabea Gleissner_](https://twitter.com/aebaR)
 
 Rabea talked about her resident apprenticeship at 8th Light. She gave an insight into what she is learning and which learning methods she finds particularly useful. She shared her reading list, gave tips for how to learn vim and recommended a number of coding katas.
 

--- a/meetups/2016-november/readme.md
+++ b/meetups/2016-november/readme.md
@@ -1,4 +1,4 @@
-#Ladies of Code LDN | [November 2016](https://www.meetup.com/Ladies-of-Code-UK/events/235075701)
+# Ladies of Code LDN | [November 2016](https://www.meetup.com/Ladies-of-Code-UK/events/235075701)
 
 This meetup was all about continuous integration and delivery. Our speaker was [Claudia Nobrega](https://www.linkedin.com/in/cl%C3%A1udia-n%C3%B3brega-7a90a383), Deployment Lead at Ve Interactive.
 

--- a/meetups/2016-october/readme.md
+++ b/meetups/2016-october/readme.md
@@ -1,16 +1,16 @@
-#Ladies of Code LDN | [October 2016](https://www.meetup.com/Ladies-of-Code-UK/events/234226231/)
+# Ladies of Code LDN | [October 2016](https://www.meetup.com/Ladies-of-Code-UK/events/234226231/)
 
 We had an evening of talks and discussion to demystify Hackathons - what to expect and how to get the most out of the experience.
 
 We had three presentations:
 
-###My experience of organising a hackathon - presented by [_Jessica Wade_](https://twitter.com/jesswade)
+### My experience of organising a hackathon - presented by [_Jessica Wade_](https://twitter.com/jesswade)
 
 Jessica shared her experience organising the "Engineer our Future" hackathon and gave us some top tips on how to turn a hackathon into a success.
 
 _Jessica has finished her PhD in the Department of Physics and Centre for Plastic Electronics at Imperial College London._
 
-###Learnings from participating in two hackathons - presented by [_Rainey David_](https://twitter.com/rainede)
+### Learnings from participating in two hackathons - presented by [_Rainey David_](https://twitter.com/rainede)
 
 Rainey shared her recent experience at two hackathons by @StartupLondon and @RedMonk in September 2016. She attended both events for free as part of their diversity program to encourage more women at their events. She built [http://bit.ly/ladyproblems](http://bit.ly/ladyproblems) at a Startup Weekend event and will talk about the team's journey.
 
@@ -18,7 +18,7 @@ The other event was a ThingMonk conference for developers with an embedded hackd
 
 If you measure success by prizes and gifts, then in September she received an amazon echo, raspberry pi, amazon vouchers, IoT books and more. However the real prize was the experience of being there, the connections she made and the support she received from her team, the event volunteers, the mentors, the coaches and the attendees!
 
-###How to Accidentally Start a Business in 54 Hours - presented by [_Claire Mitchell_](https://twitter.com/nofootnotes) and [_Michelle Garrett_](https://twitter.com/msmichellegar)
+### How to Accidentally Start a Business in 54 Hours - presented by [_Claire Mitchell_](https://twitter.com/nofootnotes) and [_Michelle Garrett_](https://twitter.com/msmichellegar)
 
 Claire and Michelle won [Startup Weekend](https://startupweekend.org/) last year, launching them on an exciting and tumultuous journey that took them to Poland and back. They shared their experiences turning a weekend project into a real business, and their tips for hackathon success.
 

--- a/meetups/2017-february/readme.md
+++ b/meetups/2017-february/readme.md
@@ -1,4 +1,4 @@
-#Ladies of Code LDN | [February 2017](https://www.meetup.com/Ladies-of-Code-UK/events/236921976/)
+# Ladies of Code LDN | [February 2017](https://www.meetup.com/Ladies-of-Code-UK/events/236921976/)
 
 This time we had two lovely speakers who talked about Golang!
 

--- a/meetups/get-together-and-build-things.md
+++ b/meetups/get-together-and-build-things.md
@@ -1,4 +1,4 @@
-#Ladies of Code LDN | Get together and build things
+# Ladies of Code LDN | Get together and build things
 
 We run this meetup once in a while because it's a great opportunity to take some time out of our diary and finally focus on that side project we've always wanted to get done, learn that new language that we've been reading about or contribute to open source. Or maybe get help with a problem that we've been stuck on for a while.
 


### PR DESCRIPTION
Turns out, the markdown formatting doesn't work anymore if you don't add a space after the hash for headings. So I added it some spaces in.